### PR TITLE
[Feat] 캘린더 오늘 이후는 누를 수 없게

### DIFF
--- a/src/components/elements/Calendar.tsx
+++ b/src/components/elements/Calendar.tsx
@@ -3,6 +3,7 @@ import moment, { Moment } from 'moment';
 import { QueryObserverResult, UseQueryResult, useQuery } from 'react-query';
 import '../../styles/components/_Calender.scss';
 import { useParams } from 'react-router';
+import { isAfter } from 'date-fns';
 import CalendarModal from './CalendarModal';
 import accounts from '../../api/accounts';
 
@@ -56,10 +57,17 @@ function Calendar({
   // 모달 오픈/클로즈 애니메이션
   const [modalAnimation, setModalAnimation] = useState('');
 
+  // const calendarModalOpen = (date: string): void => {
+  //   setSelectedDate(date);
+  //   setCalendarModal(true);
+  //   setModalAnimation('modalAnimation');
+  // };
   const calendarModalOpen = (date: string): void => {
-    setSelectedDate(date);
-    setCalendarModal(true);
-    setModalAnimation('modalAnimation');
+    if (!isAfter(new Date(date), new Date())) {
+      setSelectedDate(date);
+      setCalendarModal(true);
+      setModalAnimation('modalAnimation');
+    }
   };
 
   const firstWeek = today.clone().startOf('month').week();


### PR DESCRIPTION
1차 피드백 수정사항을 pr 하고 보니, 미래의 날짜를 누르면 가계부를 등록할 수가 있어서 오늘 이후로는 캘린더에서 선택할 수 없게 수정했습니다